### PR TITLE
added support for debian squeeze to force source builds

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,7 +57,9 @@ when "ubuntu"
     set['djbdns']['bin_dir'] = "/usr/local/bin"
   end
 when "debian"
-  if node['platform_version'].to_f >= 5.0
+  if node['platform_version'].to_f >= 6.0
+    set['djbdns']['bin_dir'] = "/usr/local/bin"
+  elsif node['platform_version'].to_f >= 5.0
     set['djbdns']['bin_dir'] = "/usr/bin"
   else
     set['djbdns']['bin_dir'] = "/usr/local/bin"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,7 +26,7 @@ node.set['djbdns']['service_type'] = value_for_platform(
 
 installation_method = value_for_platform(
     "arch" => { "default" => "aur" },
-    "debian" => { "4.0" => "source", "default" => "package" },
+    "debian" => { "4.0" => "source", "6.0" => "source", "default" => "package" },
     "ubuntu" => {
       "6.06" => "source",
       "6.10" => "source",


### PR DESCRIPTION
When trying to install dnscache on a Squeeze Vagrant machine I noticed there are no backports or repos avaiable for djbdns package. Changed slightly so it installs from source for Squeeze.
