### PR TITLE
removed runit version dependancy

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ recipe            "djbdns::server", "Sets up external TinyDNS"
   depends cb
 end
 
-depends "runit", "<= 0.16.2"
+depends "runit"
 
 %w{ ubuntu debian centos rhel arch }.each do |os|
   supports os


### PR DESCRIPTION
runit depended on 0.16.2. Removed the version dependency but not the cookbook dependency.
