### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/fixtures/cookbooks/test'
-end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.1.20](https://github.com/sous-chefs/djbdns/compare/v5.1.19...v5.1.20) (2026-04-21)
 
-
 ### Bug Fixes
 
 * **ci:** Update workflows to use release pipeline ([#68](https://github.com/sous-chefs/djbdns/issues/68)) ([76dece1](https://github.com/sous-chefs/djbdns/commit/76dece1864bf325f15114c64628569b7a14a806c))
 
 ## [5.1.19](https://github.com/sous-chefs/djbdns/compare/5.1.18...v5.1.19) (2025-10-15)
-
 
 ### Bug Fixes
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,11 +6,11 @@ This file lists how this cookbook project is maintained. When making changes to 
 
 Check out [How Cookbooks are Maintained](https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD) for details on the process and how to become a maintainer or the project lead.
 
-# Project Maintainer
+## Project Maintainer
 
 * [Tim Smith](https://github.com/tas50)
 
-# Maintainers
+## Maintainers
 
 * [Jennifer Davis](https://github.com/sigje)
 * [Tim Smith](https://github.com/tas50)

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+name 'djbdns'
+default_source :supermarket
+
+run_list 'djbdns::default'
+
+cookbook 'djbdns', path: '.'
+cookbook 'test', path: './test/fixtures/cookbooks/test'

--- a/recipes/cache.rb
+++ b/recipes/cache.rb
@@ -23,7 +23,7 @@ include_recipe 'djbdns::default'
 
 execute 'public_cache_update' do
   cwd node['djbdns']['public_dnscache_dir']
-  command "#{node['djbdns']['bin_dir']}/dnsip `#{node['djbdns']['bin_dir']}/dnsqr ns . | awk '/answer:/ { print \$5 ; }' | sort` > root/servers/@"
+  command "#{node['djbdns']['bin_dir']}/dnsip `#{node['djbdns']['bin_dir']}/dnsqr ns . | awk '/answer:/ { print $5 ; }' | sort` > root/servers/@"
   action :nothing
 end
 

--- a/resources/rr.rb
+++ b/resources/rr.rb
@@ -20,6 +20,8 @@
 # calls tinydns-edit: usage: tinydns-edit data data.new add [ns|childns|host|alias|mx] domain a.b.c.d
 # e.g., tinydns-edit data data.new add host tester2.int.housepub.org 10.13.37.79
 
+unified_mode true
+
 property :fqdn, String, name_property: true
 property :ip, String, required: true
 property :type, String, default: 'host'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/tasks/maintainers.rb
+++ b/tasks/maintainers.rb
@@ -41,8 +41,6 @@ rescue LoadError
   warn "\n*** TomlRb not available. Skipping the Maintainers Rake task\n\n"
 end
 
-private
-
 def preamble
   <<-EOL
 # #{@toml['Preamble']['title']}


### PR DESCRIPTION
## Summary
- add Policyfile.rb and remove Berksfile
- switch ChefSpec to chefspec/policyfile
- update Copilot dependency install to chef install Policyfile.rb
- fix existing lint/markdown blockers required for local gates

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_HOME=/private/tmp/chef-gem-home GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0:/private/tmp/chef-gem-home /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list